### PR TITLE
fix match for long postfix session IDs

### DIFF
--- a/postfix-log-parser.go
+++ b/postfix-log-parser.go
@@ -11,7 +11,7 @@ const (
 	TimeRegexpFormat           = `([A-Za-z]{3}\s*[0-9]{1,2} [0-9]{2}:[0-9]{2}:[0-9]{2}|^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+(?:[+-][0-2]\d:[0-5]\d|Z))`
 	HostRegexpFormat           = `([0-9A-Za-z\.]*)`
 	ProcessRegexpFormat        = `(postfix/[a-z]*\[[0-9]{1,5}\])?`
-	QueueIdRegexpFormat        = `([0-9A-Z]*)`
+	QueueIdRegexpFormat        = `([\d\w]*)`
 	MessageDetailsRegexpFormat = `((?:client=(.+)\[(.+)\])?(?:message-id=<(.+)>)?(?:from=<(.+@.+)>)?(?:to=<(.+@.+)>.*status=([a-z]+))?.*)`
 	RegexpFormat               = TimeRegexpFormat + ` ` + HostRegexpFormat + ` ` + ProcessRegexpFormat + `: ` + QueueIdRegexpFormat + `(?:\: )?` + MessageDetailsRegexpFormat
 )


### PR DESCRIPTION
Also took the liberty of using \w and \d which make sense in this context, and look cleaner. As long as the character does not match space or : it's fine.

I'm still getting a crash in my logfiles that I need to resolve but this is a good start for postfix servers with long session IDs enabled.