### PR TITLE
fix process name which can also be "trivial-rewrite" sometimes

### DIFF
--- a/postfix-log-parser.go
+++ b/postfix-log-parser.go
@@ -10,8 +10,8 @@ const (
 	TimeFormatISO8601          = "2006-01-02T15:04:05.999999-07:00"
 	TimeRegexpFormat           = `([A-Za-z]{3}\s*[0-9]{1,2} [0-9]{2}:[0-9]{2}:[0-9]{2}|^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+(?:[+-][0-2]\d:[0-5]\d|Z))`
 	HostRegexpFormat           = `([0-9A-Za-z\.]*)`
-	ProcessRegexpFormat        = `(postfix/[a-z]*\[[0-9]{1,5}\])?`
-	QueueIdRegexpFormat        = `([0-9A-Z]*)`
+	ProcessRegexpFormat        = `(postfix/[\w\-]+\[[0-9]{1,5}\])?`
+	QueueIdRegexpFormat        = `([\d\w]*)`
 	MessageDetailsRegexpFormat = `((?:client=(.+)\[(.+)\])?(?:message-id=<(.+)>)?(?:from=<(.+@.+)>)?(?:to=<(.+@.+)>.*status=([a-z]+))?.*)`
 	RegexpFormat               = TimeRegexpFormat + ` ` + HostRegexpFormat + ` ` + ProcessRegexpFormat + `: ` + QueueIdRegexpFormat + `(?:\: )?` + MessageDetailsRegexpFormat
 )


### PR DESCRIPTION
Postfix process names can container dashes, also like my other PR I think \w is cleaner than a-z. Also using + seems more proper because we know process name must be one or more of something.